### PR TITLE
Fixes scte35-104 conversion for private descriptors

### DIFF
--- a/src/scte35-to104.c
+++ b/src/scte35-to104.c
@@ -151,9 +151,19 @@ static int scte35_append_descriptor(struct splice_descriptor *sd, struct klvanc_
 		return -1;
 
 	op->descriptor_data.descriptor_count = 1;
-	op->descriptor_data.total_length = sd->extra_data.descriptor_data_length;
-	for (int i = 0; i < op->descriptor_data.total_length; i++) {
-		op->descriptor_data.descriptor_bytes[i] = sd->extra_data.descriptor_data[i];
+	op->descriptor_data.total_length = sd->extra_data.descriptor_data_length + 6;
+	// 1 byte tag + 1 byte len + 4 bytes identifier = 6 bytes
+
+	op->descriptor_data.descriptor_bytes[0] = sd->splice_descriptor_tag;
+	op->descriptor_data.descriptor_bytes[1] = sd->extra_data.descriptor_data_length + 4;
+	// Data + 4 bytes identifier
+	op->descriptor_data.descriptor_bytes[2] = (uint8_t)((sd->identifier >> 24) & 0xff);
+	op->descriptor_data.descriptor_bytes[3] = (uint8_t)((sd->identifier >> 16) & 0xff);
+	op->descriptor_data.descriptor_bytes[4] = (uint8_t)((sd->identifier >> 8) & 0xff);
+	op->descriptor_data.descriptor_bytes[5] = (uint8_t)(sd->identifier & 0xff);
+
+	for (int i = 0; i < sd->extra_data.descriptor_data_length; i++) {
+		op->descriptor_data.descriptor_bytes[6 + i] = sd->extra_data.descriptor_data[i];
 	}
 
 	return 0;

--- a/src/scte35.c
+++ b/src/scte35.c
@@ -700,13 +700,26 @@ struct scte35_splice_info_section_s *scte35_splice_info_section_parse(uint8_t *s
 
 void scte35_splice_info_section_free(struct scte35_splice_info_section_s *s)
 {
-	for (int i = 0; i < SCTE35_MAX_DESCRIPTORS; i++) {
-		if (s->descriptors[i] != NULL)
+	uint16_t i;
+	if (!s)
+		return;
+	for (i=0; i<s->descriptor_loop_count; i++)
+	{
+		if (s->descriptors[i])
+		{
 			free(s->descriptors[i]);
+			s->descriptors[i] = NULL;
+		}
 	}
-	if (s->splice_descriptor)
+	s->descriptor_loop_count = 0;
+	if (s->descriptor_loop_length && s->splice_descriptor)
+	{
 		free(s->splice_descriptor);
+		s->splice_descriptor = NULL;
+	}
+	s->descriptor_loop_length = 0;
 	free(s);
+	s = NULL;
 }
 
 struct scte35_splice_info_section_s *scte35_splice_info_section_alloc(uint8_t command_type)

--- a/src/scte35.c
+++ b/src/scte35.c
@@ -503,13 +503,13 @@ ssize_t scte35_parse_descriptors(struct scte35_splice_info_section_s *si, uint8_
 			ret = scte35_parse_descriptor(sd, buf, priv_len);
 		}
 
+		bytesRead += (sd->descriptor_length + 2);
 		if (ret == 0) {
 			si->descriptors[si->descriptor_loop_count++] = sd;
 		} else {
 			free(sd);
+			sd = NULL;
 		}
-
-		bytesRead += (sd->descriptor_length + 2);
 	}
 
 	klbs_free(bs);


### PR DESCRIPTION
- fixes private descriptors in scte-35 to scte-104 conversion
- fixes issues reported by codeQL
- fixes scte35 splice info section free